### PR TITLE
Save for ltr help that returned nothing

### DIFF
--- a/src/commands/all.js
+++ b/src/commands/all.js
@@ -1,4 +1,4 @@
-import "./twitter";
+// import "./twitter";
 import "./btcticker";
 import "./img";
 import "./wordDefinition.js";

--- a/src/commands/all.js
+++ b/src/commands/all.js
@@ -1,4 +1,4 @@
-// import "./twitter";
+import "./twitter";
 import "./btcticker";
 import "./img";
 import "./wordDefinition.js";

--- a/src/controllers/wordDefinition.js
+++ b/src/controllers/wordDefinition.js
@@ -4,16 +4,20 @@ function saveWordDefinition(word, definition) {
     return WordDefinition.create(word, definition);
 }
 
-function getWordDefinition(word) {
-    return WordDefinition.get(word);
+function updateWordDefinition(wordDefinition, definition) {
+    return WordDefinition.update(wordDefinition, definition);
+}
+
+function getWordDefinition(word, valid) {
+    return WordDefinition.get(word, valid);
 }
 
 function deleteWordDefinition(word) {
   return WordDefinition.delete(word);
 }
 
-function listWordDefinition() {
-    return WordDefinition.all();
+function listWordDefinition(valid) {
+    return WordDefinition.all(valid);
 }
 
-export default { saveWordDefinition, getWordDefinition, listWordDefinition, deleteWordDefinition };
+export default { saveWordDefinition, updateWordDefinition, getWordDefinition, listWordDefinition, deleteWordDefinition };

--- a/src/models/wordDefinition.js
+++ b/src/models/wordDefinition.js
@@ -8,8 +8,12 @@ export const WordDefinitionSchema = new mongoose.Schema({
     },
     definition: {
         type: String,
-        required: true,
         unique: false,
+    },
+    valid: {
+        type: Boolean,
+        required: true,
+        default: false
     }
 }, {
         timestamps: {}
@@ -41,14 +45,28 @@ WordDefinitionSchema.statics = {
         const wordDefinition = new this();
         wordDefinition.word = word;
         wordDefinition.definition = definition;
+        wordDefinition.valid = definition !== undefined;
         return wordDefinition.save();
     },
+
+    /**
+     * Update WordDefinition
+     * @param {String} wordDefinition - WordDefinition to be updated
+     * @param {String} newDefinition - word definition to update
+     * @return {Promise}
+     */
+    update(wordDefinition, newDefinition) {
+        wordDefinition.definition = newDefinition;
+        wordDefinition.valid = newDefinition !== undefined;
+        return wordDefinition.save();
+    },
+
     /**
      * Get WordDefinition
      * @param {String} word - Word defined
      */
-    get(word) {
-        return this.findOne({ word: word });
+    get(word, valid = true) {
+        return this.findOne({ word: word, valid: valid });
     },
     /**
      * Delete WordDefinition
@@ -59,10 +77,11 @@ WordDefinitionSchema.statics = {
     },
     /**
      * Get all WordDefinition
+     * @param {Boolean} valid - Find the valid or not definition
      * @returns {Promise}
      */
-    all() {
-        return this.find({});
+    all(valid = true) {
+        return this.find({valid: valid});
     }
 };
 


### PR DESCRIPTION
Saved in DB the word asked that returned nothing. By using the attribute `valid`.

Admin can list the non `valid` by using the command `!helpUnvalid`.
Also, using the `!helpAdd` on a non `valid` word will not trigger an error. It will just update the definition, and validate the word

Close #3
